### PR TITLE
Add new Feiertag in Berlin ("Internationaler Frauentag")

### DIFF
--- a/feiertage.go
+++ b/feiertage.go
@@ -110,6 +110,11 @@ func Valentinstag(x int) Feiertag {
 	return Feiertag{time.Date(x, time.February, 14, 0, 0, 0, 0, time.UTC), "Valentinstag"}
 }
 
+// InternationalerFrauentag is International Women's Day, a fixed date.
+func InternationalerFrauentag(x int) Feiertag {
+	return Feiertag{time.Date(x, time.March, 8, 0, 0, 0, 0, time.UTC), "Internationaler Frauentag"}
+}
+
 // Josefitag is St Joseph's Day, a fixed date.
 func Josefitag(x int) Feiertag {
 	return Feiertag{time.Date(x, time.March, 19, 0, 0, 0, 0, time.UTC), "Josefitag"}

--- a/region.go
+++ b/region.go
@@ -104,6 +104,9 @@ func Bayern(y int, inklSonntage ...bool) Region {
 // Berlin returns a Region object holding all public holidays in the state Berlin
 func Berlin(y int, inklSonntage ...bool) Region {
 	ffun := []func(int) Feiertag{}
+	if y >= 2019 {
+		ffun = append(ffun, InternationalerFrauentag)
+	}
 	return Region{"Berlin", "BE", createFeiertagsList(y, "DE", ffun)}
 }
 
@@ -280,10 +283,10 @@ func Österreich(y int, inklSonntage ...bool) Region {
 func All(y int, inklSonntage ...bool) Region {
 
 	/* ffun := []func(int) Feiertag{Neujahr, Epiphanias, HeiligeDreiKönige, Valentinstag,
-	Josefitag, Weiberfastnacht, Rosenmontag, Fastnacht, Aschermittwoch, Gründonnerstag,
-	Karfreitag, BeginnSommerzeit, Ostermontag, Walpurgisnacht, TagDerArbeit, Staatsfeiertag,
-	Florianitag, TagDerBefreiung, Muttertag, ChristiHimmelfahrt, Vatertag, PfingstMontag,
-	Fronleichnam, MariäHimmelfahrt, Rupertitag, TagDerDeutschenEinheit,
+	InternationalerFrauentag, Josefitag, Weiberfastnacht, Rosenmontag, Fastnacht, Aschermittwoch,
+	Gründonnerstag, Karfreitag, BeginnSommerzeit, Ostermontag, Walpurgisnacht, TagDerArbeit,
+	Staatsfeiertag, Florianitag, TagDerBefreiung, Muttertag, ChristiHimmelfahrt, Vatertag,
+	PfingstMontag, Fronleichnam, MariäHimmelfahrt, Rupertitag, TagDerDeutschenEinheit,
 	TagDerVolksabstimming, Nationalfeiertag, Reformationstag, Halloween, BeginnWinterzeit,
 	Allerheiligen, Allerseelen, Martinstag, Karnevalsbeginn, Leopolditag, BußUndBettag,
 	Thanksgiving, Blackfriday, Nikolaus, MariäUnbefleckteEmpfängnis, MariäEmpfängnis,
@@ -299,6 +302,9 @@ func All(y int, inklSonntage ...bool) Region {
 
 	if y != 2017 {
 		feiern = append(feiern, Reformationstag)
+	}
+	if y >= 2019 {
+		feiern = append(feiern, InternationalerFrauentag)
 	}
 	for _, f := range createCommonFeiertagsList(y) {
 		feiern = append(feiern, f)

--- a/region_test.go
+++ b/region_test.go
@@ -23,6 +23,7 @@ func TestFeiertageZahl(t *testing.T) {
 	checkAndFailRegionFeiertageZahl(t, BadenWürttemberg(2016), 12)
 	checkAndFailRegionFeiertageZahl(t, Bayern(2016), 12)
 	checkAndFailRegionFeiertageZahl(t, Berlin(2016), 9)
+	checkAndFailRegionFeiertageZahl(t, Berlin(2019), 10)
 	checkAndFailRegionFeiertageZahl(t, Brandenburg(2016), 12)
 	checkAndFailRegionFeiertageZahl(t, Brandenburg(2017), len(Brandenburg(2016).Feiertage))
 	checkAndFailRegionFeiertageZahl(t, Brandenburg(2016, false), 10)


### PR DESCRIPTION
There is a new Feiertag in Berlin from 2019 on. You will want to add it.

https://www.berlin.de/special/familien/5597854-2864562-frauentag-8-maerz-neuer-feiertag.html